### PR TITLE
Re-export escape_single_quote_string

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -41,7 +41,7 @@ pub use self::query::{
     Query, Select, SelectItem, SetExpr, SetOperator, TableAlias, TableFactor, TableWithJoins, Top,
     Values, With,
 };
-pub use self::value::{DateTimeField, TrimWhereField, Value};
+pub use self::value::{escape_single_quote_string, DateTimeField, TrimWhereField, Value};
 
 struct DisplaySeparated<'a, T>
 where


### PR DESCRIPTION
This allows users of the crate to manually escape string values, such as when embedding an identifier from AST in a generated SQL filter.