### PR TITLE
feat: Support field access with dot expression in SELECT

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -323,6 +323,11 @@ pub enum Expr {
     },
     /// An array expression e.g. `ARRAY[1, 2]`
     Array(Array),
+    /// An expression with field access, such as `SELECT (udf_returning_struct()).field`
+    DotExpr {
+        expr: Box<Expr>,
+        field: Ident,
+    },
 }
 
 impl fmt::Display for Expr {
@@ -507,6 +512,9 @@ impl fmt::Display for Expr {
             }
             Expr::Array(set) => {
                 write!(f, "{}", set)
+            }
+            Expr::DotExpr { expr, field } => {
+                write!(f, "{}.{}", expr, field)
             }
         }
     }
@@ -2457,7 +2465,7 @@ impl fmt::Display for CopyLegacyCsvOption {
     }
 }
 
-///  
+///
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MergeClause {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -518,7 +518,14 @@ impl<'a> Parser<'a> {
                         }
                     };
                 self.expect_token(&Token::RParen)?;
-                Ok(expr)
+                if !self.consume_token(&Token::Period) {
+                    return Ok(expr);
+                }
+
+                Ok(Expr::DotExpr {
+                    expr: Box::new(expr),
+                    field: self.parse_identifier()?,
+                })
             }
             Token::Placeholder(_) => {
                 self.prev_token();


### PR DESCRIPTION
This PR adds support for field access using dot expression useful for functions returning structs, e.g. `SELECT (udf_returning_struct()).field`.