### PR TITLE
feat: Add PostgreSQL array subquery constructor

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -327,6 +327,8 @@ pub enum Expr {
     },
     /// An array expression e.g. `ARRAY[1, 2]`
     Array(Array),
+    /// An array subquery constructor, e.g. `array(SELECT 1 UNION SELECT 2)`
+    ArraySubquery(Box<Query>),
     /// An expression with field access, such as `SELECT (udf_returning_struct()).field`
     DotExpr {
         expr: Box<Expr>,
@@ -440,6 +442,7 @@ impl fmt::Display for Expr {
             }
             Expr::Exists(s) => write!(f, "EXISTS ({})", s),
             Expr::Subquery(s) => write!(f, "({})", s),
+            Expr::ArraySubquery(s) => write!(f, "ARRAY({})", s),
             Expr::ListAgg(listagg) => write!(f, "{}", listagg),
             Expr::GroupingSets(sets) => {
                 write!(f, "GROUPING SETS (")?;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2307,7 +2307,7 @@ fn parse_bad_constraint() {
 
 #[test]
 fn parse_scalar_function_in_projection() {
-    let names = vec!["sqrt", "array", "foo"];
+    let names = vec!["sqrt", "foo"];
 
     for function_name in names {
         // like SELECT sqrt(id) FROM foo

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1187,6 +1187,67 @@ fn parse_array_index_expr() {
 }
 
 #[test]
+fn parse_array_subquery_expr() {
+    let sql = "SELECT ARRAY(SELECT 1 UNION SELECT 2)";
+    let select = pg().verified_only_select(sql);
+    assert_eq!(
+        &Expr::ArraySubquery(Box::new(Query {
+            with: None,
+            body: SetExpr::SetOperation {
+                op: SetOperator::Union,
+                all: false,
+                left: Box::new(SetExpr::Select(Box::new(Select {
+                    distinct: false,
+                    top: None,
+                    projection: vec![SelectItem::UnnamedExpr(Expr::Value(Value::Number(
+                        #[cfg(not(feature = "bigdecimal"))]
+                        "1".to_string(),
+                        #[cfg(feature = "bigdecimal")]
+                        "1".parse().unwrap(),
+                        false,
+                    )))],
+                    into: None,
+                    from: vec![],
+                    lateral_views: vec![],
+                    selection: None,
+                    group_by: vec![],
+                    cluster_by: vec![],
+                    distribute_by: vec![],
+                    sort_by: vec![],
+                    having: None,
+                }))),
+                right: Box::new(SetExpr::Select(Box::new(Select {
+                    distinct: false,
+                    top: None,
+                    projection: vec![SelectItem::UnnamedExpr(Expr::Value(Value::Number(
+                        #[cfg(not(feature = "bigdecimal"))]
+                        "2".to_string(),
+                        #[cfg(feature = "bigdecimal")]
+                        "2".parse().unwrap(),
+                        false,
+                    )))],
+                    into: None,
+                    from: vec![],
+                    lateral_views: vec![],
+                    selection: None,
+                    group_by: vec![],
+                    cluster_by: vec![],
+                    distribute_by: vec![],
+                    sort_by: vec![],
+                    having: None,
+                }))),
+            },
+            order_by: vec![],
+            limit: None,
+            offset: None,
+            fetch: None,
+            lock: None,
+        })),
+        expr_from_projection(only(&select.projection)),
+    );
+}
+
+#[test]
 fn test_transaction_statement() {
     let statement = pg().verified_stmt("SET TRANSACTION SNAPSHOT '000003A1-1'");
     assert_eq!(


### PR DESCRIPTION
This PR adds PostgresSQL array subquery constructor (`ARRAY(…)`) parsing and a relevant test.