### PR TITLE
feat: Allow expressions in `LIMIT`

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -266,7 +266,7 @@ impl fmt::Display for With {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Cte {
     pub alias: TableAlias,
-    pub query: Query,
+    pub query: Box<Query>,
     pub from: Option<Ident>,
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3172,7 +3172,7 @@ impl<'a> Parser<'a> {
 
         let mut cte = if self.parse_keyword(Keyword::AS) {
             self.expect_token(&Token::LParen)?;
-            let query = self.parse_query()?;
+            let query = Box::new(self.parse_query()?);
             self.expect_token(&Token::RParen)?;
             let alias = TableAlias {
                 name,
@@ -3187,7 +3187,7 @@ impl<'a> Parser<'a> {
             let columns = self.parse_parenthesized_column_list(Optional)?;
             self.expect_keyword(Keyword::AS)?;
             self.expect_token(&Token::LParen)?;
-            let query = self.parse_query()?;
+            let query = Box::new(self.parse_query()?);
             self.expect_token(&Token::RParen)?;
             let alias = TableAlias { name, columns };
             Cte {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3281,7 +3281,7 @@ fn parse_recursive_cte() {
                 quote_style: None,
             }],
         },
-        query: cte_query,
+        query: Box::new(cte_query),
         from: None,
     };
     assert_eq!(with.cte_tables.first().unwrap(), &expected);


### PR DESCRIPTION
This PR adds support for parsing expressions (like placeholders or subqueries) in `LIMIT`. It also boxes a `Query` in `Cte`, following the same approach as with other `Query` instances.