### PR TITLE
feat: Support `LOCALTIME` and `LOCALTIMESTAMP` time functions

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -435,7 +435,11 @@ impl<'a> Parser<'a> {
                         special: true,
                     }))
                 }
-                Keyword::CURRENT_TIMESTAMP | Keyword::CURRENT_TIME | Keyword::CURRENT_DATE => {
+                Keyword::CURRENT_TIMESTAMP
+                | Keyword::CURRENT_TIME
+                | Keyword::CURRENT_DATE
+                | Keyword::LOCALTIME
+                | Keyword::LOCALTIMESTAMP => {
                     self.parse_time_functions(ObjectName(vec![w.to_ident()]))
                 }
                 Keyword::CASE => self.parse_case_expr(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -29,7 +29,7 @@ use crate::dialect::*;
 use crate::keywords::{self, Keyword};
 use crate::tokenizer::*;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParserError {
     TokenizerError(String),
     ParserError(String),
@@ -51,7 +51,7 @@ macro_rules! return_ok_if_some {
     }};
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum IsOptional {
     Optional,
     Mandatory,
@@ -1576,7 +1576,7 @@ impl<'a> Parser<'a> {
         let all = self.parse_keyword(Keyword::ALL);
         let distinct = self.parse_keyword(Keyword::DISTINCT);
         if all && distinct {
-            return parser_err!("Cannot specify both ALL and DISTINCT".to_string());
+            parser_err!("Cannot specify both ALL and DISTINCT".to_string())
         } else {
             Ok(distinct)
         }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -286,7 +286,7 @@ impl fmt::Display for Whitespace {
 }
 
 /// Tokenizer error
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TokenizerError {
     pub message: String,
     pub line: u64,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4739,6 +4739,38 @@ fn parse_time_functions() {
 
     // Validating Parenthesis
     one_statement_parses_to("SELECT CURRENT_DATE", sql);
+
+    let sql = "SELECT LOCALTIME()";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("LOCALTIME")]),
+            args: vec![],
+            over: None,
+            distinct: false,
+            special: false,
+        }),
+        expr_from_projection(&select.projection[0])
+    );
+
+    // Validating Parenthesis
+    one_statement_parses_to("SELECT LOCALTIME", sql);
+
+    let sql = "SELECT LOCALTIMESTAMP()";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("LOCALTIMESTAMP")]),
+            args: vec![],
+            over: None,
+            distinct: false,
+            special: false,
+        }),
+        expr_from_projection(&select.projection[0])
+    );
+
+    // Validating Parenthesis
+    one_statement_parses_to("SELECT LOCALTIMESTAMP", sql);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for parsing `LOCALTIME` and `LOCALTIMESTAMP` without parentheses as a time function with no arguments. These are used by QuickSight in the generated queries with filters.
It also includes a cherry-picked upstream commit to fix clippy issues.