### PR TITLE
feat: Support multiple values in `SET`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1779,12 +1779,13 @@ impl fmt::Display for Statement {
                     .iter()
                     .map(|key_value| {
                         format!(
-                            "{}{}",
+                            "{}{} = {}",
                             if key_value.local { "LOCAL " } else { "" },
+                            key_value.key,
                             key_value
                                 .value
                                 .iter()
-                                .map(|value| format!("{} = {}", key_value.key, value))
+                                .map(|value| format!("{}", value))
                                 .collect::<Vec<String>>()
                                 .join(", ")
                         )

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -790,6 +790,29 @@ fn parse_set() {
         }
     );
 
+    let stmt = pg().verified_stmt("SET a = b, c");
+    assert_eq!(
+        stmt,
+        Statement::SetVariable {
+            key_values: [SetVariableKeyValue {
+                key: "a".into(),
+                value: vec![
+                    Expr::Identifier(Ident {
+                        value: "b".into(),
+                        quote_style: None
+                    }),
+                    Expr::Identifier(Ident {
+                        value: "c".into(),
+                        quote_style: None
+                    }),
+                ],
+                local: false,
+                hivevar: false,
+            }]
+            .to_vec()
+        }
+    );
+
     let stmt = pg_and_generic().verified_stmt("SET a = 'b'");
     assert_eq!(
         stmt,


### PR DESCRIPTION
b098e2d added ability to set several comma-separated variables, e.g. `SET a = b, c = d`. This however came with a regression that does not allow setting several comma-separated values for a variable, e.g. `SET a = b, c`.

One case where this is problematic is `SET search_path = public, other_schema` with PostgreSQL.
This PR addresses the issue, allowing multiple values for a variable, instead of several variables (which is invalid syntax in Postgres) to be set when PostgreSQL or Redshift dialect is enabled.

Related test is included.