### PR TITLE
fix: Support `SET ROLE` with `TO`/`=`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3682,6 +3682,7 @@ impl<'a> Parser<'a> {
                 });
             }
         } else if self.parse_keyword(Keyword::ROLE) {
+            let _ = self.consume_token(&Token::Eq) || self.parse_keyword(Keyword::TO);
             let role_name = if self.parse_keyword(Keyword::NONE) {
                 None
             } else {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -918,7 +918,10 @@ fn parse_set_role() {
         }
     );
 
-    let stmt = pg_and_generic().verified_stmt("SET LOCAL ROLE \"rolename\"");
+    let stmt = pg_and_generic().one_statement_parses_to(
+        "SET LOCAL ROLE = \"rolename\"",
+        "SET LOCAL ROLE \"rolename\"",
+    );
     assert_eq!(
         stmt,
         Statement::SetRole {
@@ -931,7 +934,8 @@ fn parse_set_role() {
         }
     );
 
-    let stmt = pg_and_generic().verified_stmt("SET ROLE 'rolename'");
+    let stmt =
+        pg_and_generic().one_statement_parses_to("SET ROLE TO 'rolename'", "SET ROLE 'rolename'");
     assert_eq!(
         stmt,
         Statement::SetRole {


### PR DESCRIPTION
This PR adds support for `SET ROLE` to be set using `SET ROLE TO` or `SET ROLE =` syntax that has been lost with c3e9e07. Tests have been modified accordingly.