### PR TITLE
fix: unary negation operator with operators: `Mul`, `Div` and `Mod`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -516,7 +516,7 @@ impl<'a> Parser<'a> {
                 };
                 Ok(Expr::UnaryOp {
                     op,
-                    expr: Box::new(self.parse_subexpr(Self::PLUS_MINUS_PREC)?),
+                    expr: Box::new(self.parse_subexpr(Self::MUL_DIV_MOD_OP_PREC)?),
                 })
             }
             tok @ Token::DoubleExclamationMark
@@ -1485,6 +1485,7 @@ impl<'a> Parser<'a> {
     }
 
     // use https://www.postgresql.org/docs/7.0/operators.htm#AEN2026 as a reference
+    const MUL_DIV_MOD_OP_PREC: u8 = 40;
     const PLUS_MINUS_PREC: u8 = 30;
     const XOR_PREC: u8 = 24;
     const TIME_ZONE_PREC: u8 = 20;
@@ -1554,7 +1555,9 @@ impl<'a> Parser<'a> {
             Token::Caret | Token::Sharp | Token::ShiftRight | Token::ShiftLeft => Ok(22),
             Token::Ampersand => Ok(23),
             Token::Plus | Token::Minus => Ok(Self::PLUS_MINUS_PREC),
-            Token::Mul | Token::Div | Token::Mod | Token::StringConcat => Ok(40),
+            Token::Mul | Token::Div | Token::Mod | Token::StringConcat => {
+                Ok(Self::MUL_DIV_MOD_OP_PREC)
+            }
             Token::DoubleColon => Ok(50),
             Token::ExclamationMark => Ok(50),
             Token::LBracket => Ok(50),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -683,7 +683,7 @@ fn parse_compound_expr_2() {
 }
 
 #[test]
-fn parse_unary_math() {
+fn parse_unary_math_with_plus() {
     use self::Expr::*;
     let sql = "- a + - b";
     assert_eq!(
@@ -693,6 +693,26 @@ fn parse_unary_math() {
                 expr: Box::new(Identifier(Ident::new("a"))),
             }),
             op: BinaryOperator::Plus,
+            right: Box::new(UnaryOp {
+                op: UnaryOperator::Minus,
+                expr: Box::new(Identifier(Ident::new("b"))),
+            }),
+        },
+        verified_expr(sql)
+    );
+}
+
+#[test]
+fn parse_unary_math_with_multiply() {
+    use self::Expr::*;
+    let sql = "- a * - b";
+    assert_eq!(
+        BinaryOp {
+            left: Box::new(UnaryOp {
+                op: UnaryOperator::Minus,
+                expr: Box::new(Identifier(Ident::new("a"))),
+            }),
+            op: BinaryOperator::Multiply,
             right: Box::new(UnaryOp {
                 op: UnaryOperator::Minus,
                 expr: Box::new(Identifier(Ident::new("b"))),


### PR DESCRIPTION
This PR cherry-picks an upstream commit fixing the issue with unary operator having higher precedence than several binary operators, such as `*`, `/`, `%`, `||`, etc. Related test is included.