### PR TITLE
feat: Support placeholders in `OFFSET`, `FETCH ...`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2906,6 +2906,7 @@ impl<'a> Parser<'a> {
     pub fn parse_number_value(&mut self) -> Result<Value, ParserError> {
         match self.parse_value()? {
             v @ Value::Number(_, _) => Ok(v),
+            v @ Value::Placeholder(_) => Ok(v),
             _ => {
                 self.prev_token();
                 self.expected("literal number", self.peek_token())
@@ -4478,7 +4479,7 @@ impl<'a> Parser<'a> {
         if self.parse_keyword(Keyword::ALL) {
             Ok(None)
         } else {
-            Ok(Some(self.parse_expr()?))
+            Ok(Some(Expr::Value(self.parse_number_value()?)))
         }
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4852,6 +4852,20 @@ fn test_placeholder() {
         ast.limit,
         Some(Expr::Value(Value::Placeholder("$1".into())))
     );
+
+    let sql = "SELECT * FROM student OFFSET $1";
+    let ast = dialects.verified_query(sql);
+    assert_eq!(
+        ast.offset.map(|offset| offset.value),
+        Some(Expr::Value(Value::Placeholder("$1".into())))
+    );
+
+    let sql = "SELECT * FROM student FETCH FIRST $1 ROWS ONLY";
+    let ast = dialects.verified_query(sql);
+    assert_eq!(
+        ast.fetch.map(|fetch| fetch.quantity),
+        Some(Some(Expr::Value(Value::Placeholder("$1".into()))))
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for placeholders in `OFFSET`, `FETCH ...` by patching `parse_number_value` to accept placeholders; previous solution only explicitly accounted for `LIMIT`. Related tests are included.